### PR TITLE
[Reviewer: Rob] Fixes to clearwater-sysstat

### DIFF
--- a/clearwater-diags-monitor/etc/cron.d/clearwater-sysstat
+++ b/clearwater-diags-monitor/etc/cron.d/clearwater-sysstat
@@ -1,2 +1,5 @@
 # Get activity reports every minute - this is a finer granularity than the default /etc/cron.d/sysstat
-* * * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d`
+# Specify -F to force rotation at midnight.
+0 0 * * * root /usr/lib/sysstat/sadc -F 1 1 /var/log/sysstat/clearwater-sa`date +\%d` 2>&1 > /dev/null
+1-59 0 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` 2>&1 > /dev/null
+* 1-23 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` 2>&1 > /dev/null

--- a/clearwater-diags-monitor/etc/cron.d/clearwater-sysstat
+++ b/clearwater-diags-monitor/etc/cron.d/clearwater-sysstat
@@ -1,5 +1,5 @@
 # Get activity reports every minute - this is a finer granularity than the default /etc/cron.d/sysstat
 # Specify -F to force rotation at midnight.
-0 0 * * * root /usr/lib/sysstat/sadc -F 1 1 /var/log/sysstat/clearwater-sa`date +\%d` 2>&1 > /dev/null
-1-59 0 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` 2>&1 > /dev/null
-* 1-23 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` 2>&1 > /dev/null
+0 0 * * * root /usr/lib/sysstat/sadc -F 1 1 /var/log/sysstat/clearwater-sa`date +\%d` > /dev/null 2>&1
+1-59 0 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` > /dev/null 2>&1
+* 1-23 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` > /dev/null 2>&1


### PR DESCRIPTION
Rob, please could you review this small change to:
- Send clearwater-sysstat output to /dev/null, to prevent entries like this in syslog:
/var/log/syslog.1:Feb 16 06:23:01 sproutA CRON[30594]: (CRON) info (No MTA installed, discarding output)"
- Create a new file clearwater-sa<day> at the start of each day, rather than appending to any existing one.