### PR TITLE
Merge local_config changes

### DIFF
--- a/clearwater-ovf-config/payload/var/cc-ovf/default.cfg/etc/clearwater/local_config
+++ b/clearwater-ovf-config/payload/var/cc-ovf/default.cfg/etc/clearwater/local_config
@@ -7,20 +7,20 @@ else
    namespace_prefix=
    signaling_dns_server=$(grep "^[[:space:]]*nameserver" /run/dnsmasq/resolv.conf | awk '{print $2}'|sed -e :a -e N -e 's/\n/,/' -e ta)
 fi
-sig_nic=$( $namespace_prefix /sbin/ifconfig -s|grep eth|awk '{print $1}'|head -1)
+sig_nic=$( $namespace_prefix /sbin/ifconfig -s 2>&1 |grep eth|awk '{print $1}'|head -1)
 mgmt_nic=$( /sbin/ifconfig -s|grep eth|awk '{print $1}'|head -1)
 
 # Local IP configuration. If we have a V6 IP use it, otherwise use the V4
-local_ip4=$( $namespace_prefix ip -4 addr show dev $sig_nic|grep global|sed -e 's#^.*inet* \([^/]*\)/.*$#\1#' )
-local_ip6=$( $namespace_prefix ip -6 addr show dev $sig_nic|grep global|sed -e 's#^.*inet6* \([^/]*\)/.*$#\1#' )
+local_ip4=$( $namespace_prefix ip -4 addr show dev $sig_nic 2>&1 |grep global|sed -e 's#^.*inet* \([^/]*\)/.*$#\1#' )
+local_ip6=$( $namespace_prefix ip -6 addr show dev $sig_nic 2>&1 |grep global|sed -e 's#^.*inet6* \([^/]*\)/.*$#\1#' )
 local_ip=$local_ip4
 public_ip=$local_ip
 if echo "$[sig_protocol]" | egrep -q "^[iI][pP][vV]6$"; then
     local_ip=$local_ip6
 fi
 if [ "${mgmt_nic}" != "${sig_nic}" ]; then
-   management_ip4=$( ip -4 addr show dev $mgmt_nic|grep global|sed -e 's#^.*inet* \([^/]*\)/.*$#\1#' )
-   management_ip6=$( ip -6 addr show dev $mgmt_nic|grep global|sed -e 's#^.*inet6* \([^/]*\)/.*$#\1#' )
+   management_ip4=$( ip -4 addr show dev $mgmt_nic 2>&1 |grep global|sed -e 's#^.*inet* \([^/]*\)/.*$#\1#' )
+   management_ip6=$( ip -6 addr show dev $mgmt_nic 2>&1 |grep global|sed -e 's#^.*inet6* \([^/]*\)/.*$#\1#' )
    management_local_ip=$management_ip4
    if echo "$[mgmt_protocol]" | egrep -q "^[iI][pP][vV]6$"; then
        management_local_ip=$management_ip6
@@ -34,8 +34,12 @@ management_public_ip=$management_local_ip
 home_domain=$(hostname -d)
 public_hostname=$(hostname)
 
-local_site_name=$[local_site_name]
-remote_site_name=$[remote_site_name]
+if [ ! -z "$[local_site_name]" ]; then
+   local_site_name=$[local_site_name]
+fi
+if [ ! -z "$[remote_site_name]" ]; then
+   remote_site_name=$[remote_site_name]
+fi
 
 etcd_cluster=$[etcd_cluster]
 node_idx=$[node_idx]


### PR DESCRIPTION
Merge changes to default local_config file to prevent spurious
"seting the network namespace "signalling" failed: Operation not permitted" warnings on SSH access (SFR479638).