### PR TITLE
[Reviewer: Steve] Handle multiple DNS servers on the signaling interface

### DIFF
--- a/clearwater-ovf-config/payload/etc/rc.first.d/ovf-sc.sh
+++ b/clearwater-ovf-config/payload/etc/rc.first.d/ovf-sc.sh
@@ -964,10 +964,18 @@ if [[ "${sig_nic}" != "${mgmt_nic}" && ! -z "$new_domain_name_servers" ]]; then
 
     echo_and_run ip netns exec signaling route add default gateway $new_routers dev ${sig_nic} 2>&1 | sed -e 's#^#   #'
     mkdir -p /etc/netns/signaling
+    truncate -s 0 /etc/netns/signaling/resolv.conf
     if [ "${sig_protocol^^}" == "IPV6" ]; then
-        printf "nameserver $new_dhcp6_name_servers\n" > /etc/netns/signaling/resolv.conf
+        # Add one line for each value. Currently separated by whitespace
+        for server in ${new_dhcp6_name_servers}
+        do
+            printf "nameserver $server\n" >> /etc/netns/signaling/resolv.conf
+        done
     else
-        printf "nameserver $new_domain_name_servers\n" > /etc/netns/signaling/resolv.conf
+        for server in ${new_domain_name_servers}
+        do
+            printf "nameserver $server\n" >> /etc/netns/signaling/resolv.conf
+        done
     fi
     printf "Debug info (signaling netns routing table):\n" 2>&1 | sed -e 's#^#   #'
     echo_and_run ip netns exec signaling route 2>&1 | sed -e "s#^#     ${LINENO} #"


### PR DESCRIPTION
Hi Steve,

This is a fix for http://sfr/prodAsp/scripts/MSG/Issue.asp?issue_id=443487 where we don't handle multiple DNS servers on the signaling interface (another artifact of the way we configure the signaling interface).

I've tested the fix on CC4-sprout1.

Please could you review?

One thing I'm less happy about is that we delete the contents of the signaling resolv.conf file each time we run this script, which may end up nuking config put there manually (athough I'm not sure if doing so is supported, but worth noting to avoid a duff workaround)