### PR TITLE
[Reviewer: Steve] Dont write to stdout in cleanup cron job

### DIFF
--- a/clearwater-infrastructure/etc/cron.hourly/clearwater-cleanup
+++ b/clearwater-infrastructure/etc/cron.hourly/clearwater-cleanup
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-exec >  >( stdbuf -i0 -o0 -e0 tee /var/log/clearwater-cleanup.log )
-exec 2>&1
+exec >/var/log/clearwater-cleanup.log
 
 set +e
 
-echo /usr/bin/clearwater-cleandir /var/log /var/clearwater-diags-monitor/dumps --limit 10% --before now
-/usr/bin/clearwater-cleandir /var/log /var/clearwater-diags-monitor/dumps --limit 10% --before now
+command='/usr/bin/clearwater-cleandir /var/log /var/clearwater-diags-monitor/dumps --limit 10% --before now'
+echo "$command"
+$command
 
-exec 1>&-
 exit 0


### PR DESCRIPTION
Hi Steve,

This is a fix to stop CRON spamming /var/log/syslog/ with an error about not having a mail service each time we run clearwater-cleanup.

Tested on CC4

Please could you review?

I'll also make a PR in cwc-infra for Dev to review.