### PR TITLE
Improve Monit polling behavior during monitored process restart

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/cw-flag
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/cw-flag
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# @file cw-flag
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# Utility script which allows semi-permanent flags to be set and cleared.
+
+FLAG_DIR=/tmp/cw-flags
+USAGE="Usage: flag {clear|set|read} <flag_name>" >&2
+TIMEOUT_S=60
+
+method=$1
+flag_file=$FLAG_DIR/$2
+
+# Clears the flag by removing the flag file.
+clear_flag() {
+  rm -f $flag_file
+}
+
+# Clears the flag if it has been set for longer than $TIMEOUT_S.
+timeout_flag() {
+  if [ -f $flag_file ]; then
+    flag_time=$( expr `date +%s` - `stat -c %Y $flag_file` )
+    if [ $flag_time -gt $TIMEOUT_S ]; then
+      clear_flag
+    fi
+  fi
+}
+
+# Sets the flag by (re)creating the flag file.
+set_flag() {
+  mkdir -p $FLAG_DIR
+  touch $flag_file
+}
+
+# Reads the flag, returning 1 if the flag is set and 0 if it is clear.
+read_flag() {
+  timeout_flag # Timeout the flag if necessary
+  if [ -f $flag_file ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+case "$method" in
+
+  clear)
+    clear_flag
+    ;;
+
+  set)
+    set_flag
+    ;;
+
+  read)
+    read_flag
+    exit $?
+    ;;
+
+  *)
+    echo $USAGE
+    ;;
+
+esac

--- a/clearwater-infrastructure/usr/share/clearwater/bin/poll-http
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/poll-http
@@ -51,7 +51,9 @@ rc=$?
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
   echo HTTP failed to $http_url   >&2
+  echo "stderr was:"              >&2
   cat /tmp/poll-http.sh.stderr.$$ >&2
+  echo "stdout was:"              >&2
   cat /tmp/poll-http.sh.stdout.$$ >&2
 fi
 rm -f /tmp/poll-http.sh.stderr.$$ /tmp/poll-http.sh.stdout.$$

--- a/clearwater-infrastructure/usr/share/clearwater/bin/process-stability
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/process-stability
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# @file process-stability
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# Used for monitoring the stability of a process.
+
+method=$1
+process_name=$2
+grace_period=$3
+abort_flag_name="$process_name-aborting-flag"
+
+usage="Usage: check-stability {check|reset|aborted} <process name> <grace period (s)>"
+
+[ $# = 3 ] || { echo $usage >&2 ; exit 2; }
+
+# Returns 1 if the process has not been running for at least the grace period,
+# or the abort flag is set (and has not timed out). Returns 2 if there is no
+# process matching the value in the pidfile. Returns 0 otherwise.
+check_stability() {
+  pidfile=/var/run/$process_name/$process_name.pid
+
+  # It's expected that there might not be a pidfile
+  pid=$( cat $pidfile 2>/dev/null)
+
+  # Determine the uptime
+  uptime=$( ps -p $pid -o etimes= 2>/dev/null) || { echo "No process matching value from pidfile: $pid " >&2 ; return 1 ; }
+
+  if ! /usr/share/clearwater/bin/cw-flag read $abort_flag_name; then
+    echo "process is unstable as it is currently aborting" >&2
+    exit 1
+  elif [ "$uptime" -lt "$grace_period" ]; then
+    uptime_no_whitespace=$( echo -e $uptime | tr -d '[:space:]')
+    echo "process is unstable as it has not been up for long enough ($uptime_no_whitespace s < $grace_period s)" >&2
+    return 1
+  else
+    return 0
+  fi
+}
+
+# Clears the abort flag - should be called when (re)starting the process.
+reset_stability() {
+  /usr/share/clearwater/bin/cw-flag clear $abort_flag_name
+}
+
+aborted_stability() {
+  /usr/share/clearwater/bin/cw-flag set $abort_flag_name
+}
+
+case "$method" in
+
+  check)
+    check_stability
+    exit $?
+    ;;
+
+  reset)
+    reset_stability
+    ;;
+
+  aborted)
+    aborted_stability
+    ;;
+
+  *)
+    echo $usage
+    ;;
+
+esac


### PR DESCRIPTION
This is PR [#522](https://github.com/Metaswitch/clearwater-infrastructure/pull/522) from the PC project backapplied to CWC v10. 

Related PRs for process-specific fixes are referenced bellow.

I have tested the fix by running a live test for each of the processes in question except ralf.  